### PR TITLE
Fixed example

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ randomOperation = oneof
 So far, all functions we've used are provided by `QuickCheck` itself. Let's now write the test property:
 
 ```haskell
-prop_satisfies_invariant :: Property
+prop_satisfies_invariant :: Gen Property
 prop_satisfies_invariant = sized $ \s -> return . property $ go newModel s
   where go :: Model -> Int -> PropM Bool
         go _     0    = return True

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ prop_satisfies_invariant = sized $ \s -> return . property $ go newModel s
   where go :: Model -> Int -> PropM Bool
         go _     0    = return True
         go model size = do
-          (description, operation) <- generate randomOperation
+          (description, operation) <- gen randomOperation
           logMessageLn $ "Operation: " ++ description
           let model' = operation model
           logMessageLn $ "Model is now: " ++ show model'

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ So far, all functions we've used are provided by `QuickCheck` itself. Let's now 
 
 ```haskell
 prop_satisfies_invariant :: Property
-prop_satisfies_invariant = sized $ \s -> property $ go newModel s
+prop_satisfies_invariant = sized $ \s -> return . property $ go newModel s
   where go :: Model -> Int -> PropM Bool
         go _     0    = return True
         go model size = do


### PR DESCRIPTION
The example, as it's written, doesn't work because of the backward
compatibility note in:
http://hackage.haskell.org/package/QuickCheck-2.8.1/docs/Test-QuickCheck-Property.html#t:Property

You may want to adjust the wording in the tutorial consequently :)
